### PR TITLE
fix: linux: jiffies type size

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -84,7 +84,8 @@ const char * system_get_uuid_char(void);
 
 /* time */
 #if HAVE_CLOCK_GETTIME
-static inline u32_t jive_jiffies(void)
+typedef uint64_t jiffies_t;
+static inline jiffies_t jive_jiffies(void)
 {
 	struct timespec now;
 
@@ -92,6 +93,7 @@ static inline u32_t jive_jiffies(void)
 	return (now.tv_sec*1000)+(now.tv_nsec/1000000);
 }
 #else
+typedef u32_t jiffies_t;
 #define jive_jiffies() SDL_GetTicks()
 #endif
 

--- a/src/jive.h
+++ b/src/jive.h
@@ -273,7 +273,7 @@ struct jive_gesture_event {
 
 struct jive_event {
 	JiveEventType type;
-	Uint32 ticks;
+	jiffies_t ticks;
 
 	union {
 		struct jive_scroll_event scroll;

--- a/src/jive_dns.c
+++ b/src/jive_dns.c
@@ -200,7 +200,7 @@ static int dns_resolver_thread(void *p) {
 	size_t len;
 	char *buf;
 	char *failed_error = NULL;
-	Uint32 failed_timeout = 0;
+	jiffies_t failed_timeout = 0;
 
 	while (1) {
 		if (recv(fd, &len, sizeof(len), 0) < 0) {
@@ -225,7 +225,7 @@ static int dns_resolver_thread(void *p) {
 			#endif
 		}
 		else if (failed_error && !stat_resolv_conf()) {
-			Uint32 now = jive_jiffies();
+			jiffies_t now = jive_jiffies();
 			
 			if (now - failed_timeout < RESOLV_TIMEOUT) {
 				write_str(fd, failed_error);

--- a/src/jive_font.c
+++ b/src/jive_font.c
@@ -240,7 +240,7 @@ static int width_ttf_font(JiveFont *font, const char *str) {
 
 static SDL_Surface *draw_ttf_font(JiveFont *font, Uint32 color, const char *str) {
 #ifdef JIVE_PROFILE_BLIT
-	Uint32 t0 = jive_jiffies(), t1;
+	jiffies_t t0 = jive_jiffies(), t1;
 #endif //JIVE_PROFILE_BLIT
 	SDL_Color clr;
 	SDL_Surface *srf;

--- a/src/jive_framework.c
+++ b/src/jive_framework.c
@@ -560,7 +560,7 @@ int jiveL_set_update_screen(lua_State *L) {
 
 static int _draw_screen(lua_State *L) {
 	JiveSurface *srf;
-	Uint32 t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0;
+	jiffies_t t0 = 0, t1 = 0, t2 = 0, t3 = 0, t4 = 0;
 	clock_t c0 = 0, c1 = 0;
 	bool_t standalone_draw, drawn = false;
 
@@ -714,7 +714,7 @@ static int _draw_screen(lua_State *L) {
 				t3 = t2;
 			}
 			printf("update_screen > %dms: %4dms (%dms) [layout:%dms animate:%dms background:%dms draw:%dms]\n",
-				   perfwarn.screen, t4-t0, (int)((c1-c0) * 1000 / CLOCKS_PER_SEC), t1-t0, t2-t1, t3-t2, t4-t3);
+				   perfwarn.screen, (int)(t4-t0), (int)((c1-c0) * 1000 / CLOCKS_PER_SEC), (int)(t1-t0), (int)(t2-t1), (int)(t3-t2), (int)(t4-t3));
 		}
 	}
 	
@@ -864,7 +864,7 @@ void jive_queue_event(JiveEvent *evt) {
 
 int jiveL_dispatch_event(lua_State *L) {
 	Uint32 r = 0;
-	Uint32 t0 = 0, t1 = 0;
+	jiffies_t t0 = 0, t1 = 0;
 	clock_t c0 = 0, c1 = 0;
 
 	/* stack is:
@@ -942,7 +942,7 @@ int jiveL_dispatch_event(lua_State *L) {
 		t1 = jive_jiffies();
 		c1 = clock();
 		if (t1-t0 > perfwarn.event) {
-			printf("process_event > %dms: %4dms (%dms) ", perfwarn.event, t1-t0, (int)((c1-c0) * 1000 / CLOCKS_PER_SEC));
+			printf("process_event > %dms: %4dms (%dms) ", perfwarn.event, (int)(t1-t0), (int)((c1-c0) * 1000 / CLOCKS_PER_SEC));
 			lua_getglobal(L, "tostring");
 			lua_pushvalue(L, 2);
 			lua_call(L, 1, 1);
@@ -1121,7 +1121,8 @@ int jiveL_event(lua_State *L) {
 
 
 int jiveL_get_ticks(lua_State *L) {
-	lua_pushinteger(L, jive_jiffies());
+//	lua_pushinteger(L, jive_jiffies());
+	lua_pushnumber(L, jive_jiffies());
 	return 1;
 }
 

--- a/src/jive_surface.c
+++ b/src/jive_surface.c
@@ -777,7 +777,7 @@ static void _blit_tile(JiveTile *tile, JiveSurface *dst, Uint16 dx, Uint16 dy, U
 
 void jive_tile_blit(JiveTile *tile, JiveSurface *dst, Uint16 dx, Uint16 dy, Uint16 dw, Uint16 dh) {
 #ifdef JIVE_PROFILE_BLIT
-	Uint32 t0 = jive_jiffies(), t1;
+	jiffies_t t0 = jive_jiffies(), t1;
 #endif //JIVE_PROFILE_BLIT
 	Uint16 mw, mh;
 
@@ -802,7 +802,7 @@ void jive_tile_blit(JiveTile *tile, JiveSurface *dst, Uint16 dx, Uint16 dy, Uint
 
 void jive_tile_blit_centered(JiveTile *tile, JiveSurface *dst, Uint16 dx, Uint16 dy, Uint16 dw, Uint16 dh) {
 #ifdef JIVE_PROFILE_BLIT
-	Uint32 t0 = jive_jiffies(), t1;
+	jiffies_t t0 = jive_jiffies(), t1;
 #endif //JIVE_PROFILE_BLIT
 	Uint16 mw, mh;
 
@@ -1242,7 +1242,7 @@ void jive_surface_flip(JiveSurface *srf) {
 
 void jive_surface_blit(JiveSurface *src, JiveSurface *dst, Uint16 dx, Uint16 dy) {
 #ifdef JIVE_PROFILE_BLIT
-	Uint32 t0 = jive_jiffies(), t1;
+	jiffies_t t0 = jive_jiffies(), t1;
 #endif //JIVE_PROFILE_BLIT
 
 	SDL_Rect dr;
@@ -1261,7 +1261,7 @@ void jive_surface_blit(JiveSurface *src, JiveSurface *dst, Uint16 dx, Uint16 dy)
 void jive_surface_blit_clip(JiveSurface *src, Uint16 sx, Uint16 sy, Uint16 sw, Uint16 sh,
 			  JiveSurface* dst, Uint16 dx, Uint16 dy) {
 #ifdef JIVE_PROFILE_BLIT
-	Uint32 t0 = jive_jiffies(), t1;
+	jiffies_t t0 = jive_jiffies(), t1;
 #endif //JIVE_PROFILE_BLIT
 
 	SDL_Rect sr, dr;
@@ -1279,7 +1279,7 @@ void jive_surface_blit_clip(JiveSurface *src, Uint16 sx, Uint16 sy, Uint16 sw, U
 
 void jive_surface_blit_alpha(JiveSurface *src, JiveSurface *dst, Uint16 dx, Uint16 dy, Uint8 alpha) {
 #ifdef JIVE_PROFILE_BLIT
-	Uint32 t0 = jive_jiffies(), t1;
+	jiffies_t t0 = jive_jiffies(), t1;
 #endif //JIVE_PROFILE_BLIT
 
 	SDL_Rect dr;

--- a/src/jive_widget.c
+++ b/src/jive_widget.c
@@ -424,7 +424,7 @@ int jiveL_widget_check_skin(lua_State *L) {
 int jiveL_widget_check_layout(lua_State *L) {
 	JiveWidget *peer;
 
-	Uint32 t0 = 0, t1 = 0, t2 = 0;
+	jiffies_t t0 = 0, t1 = 0, t2 = 0;
 	clock_t c0 = 0, c1 = 0;
 
 	/* stack is:
@@ -477,7 +477,7 @@ int jiveL_widget_check_layout(lua_State *L) {
 				lua_pushvalue(L, 1);
 				lua_call(L, 1, 1);
 				printf("widget_layout > %dms: %3dms (%dms) [%s skin:%dms layout:%dms]\n",
-					   perfwarn.layout, t2-t0, (int)((c1-c0) * 1000 / CLOCKS_PER_SEC), lua_tostring(L, -1), t1-t0, t2-t1);
+					   perfwarn.layout, (int)(t2-t0), (int)((c1-c0) * 1000 / CLOCKS_PER_SEC), lua_tostring(L, -1), (int)(t1-t0), (int)(t2-t1));
 				lua_pop(L, 1);
 			}
 		}

--- a/src/jive_window.c
+++ b/src/jive_window.c
@@ -169,7 +169,7 @@ int jiveL_window_iterate(lua_State *L) {
 
 
 static int draw_closure(lua_State *L) {
-	Uint32 t0 = 0, t1 = 0;
+	jiffies_t t0 = 0, t1 = 0;
 
 	if (perfwarn.draw) t0 = jive_jiffies();
 
@@ -186,7 +186,7 @@ static int draw_closure(lua_State *L) {
 			lua_getglobal(L, "tostring");
 			lua_pushvalue(L, 1);
 			lua_call(L, 1, 1);
-			printf("widget_draw   > %dms: %4dms [%s]\n", perfwarn.draw, t1-t0, lua_tostring(L, -1));
+			printf("widget_draw   > %dms: %4dms [%s]\n", perfwarn.draw, (int)(t1-t0), lua_tostring(L, -1));
 			lua_pop(L, 1);
 		}
 	}

--- a/src/system.c
+++ b/src/system.c
@@ -103,7 +103,7 @@ static int system_lua_get_machine(lua_State *L) {
 
 
 static int system_get_uptime(lua_State *L) {
-	Uint32 uptime;
+	jiffies_t uptime;
 	int updays, upminutes, uphours;
 
 	// FIXME wraps around after 49.7 days


### PR DESCRIPTION
On linux clock_gettime is used instead of SDL_GetTicks, for calculating jiffies.

It is possible to increase the size of the type from unsigned 32 bit to unsigned 64 bit values.

Add a new type jiffies_t
If HAVE_CLOCK_GETTIME is defined this is uint64_t
otherwise it is u32_t

Change variables from Uint32 to jiffies_t in C source code, and in lua funtion getTicks, return jiffies value usingi lua_pushnumber instead of lua_pushinteger